### PR TITLE
Handle some syntax errors

### DIFF
--- a/EsFormatter.py
+++ b/EsFormatter.py
@@ -43,7 +43,7 @@ class EsformatterCommand(sublime_plugin.TextCommand):
         '''When formatting whole lines there might be a syntax error because we select
         the whole line content. In that case, fall-back to the user selection.'''
         if (lastError is None and threads is not None):
-            self.replaceSelections(threads)
+            self.replaceSelections(threads, None)
         else:
             # Format each and every selection block
             threads = []
@@ -127,7 +127,8 @@ class NodeCall(threading.Thread):
                 self.result = re.sub(r'(\r|\r\n|\n)\Z', '', str(stdout, encoding='utf-8'))
 
             if stderr:
-                sublime.error_message(stderr)
+                self.result = False
+                self.error = str(stderr)
 
         except Exception as e:
             self.result = False
@@ -142,17 +143,10 @@ def getStartupInfo():
     return None
 
 def getNodeCommand(libPath, options=None):
-    # I wonder if there's a better way to do this in Python instead of nested if-s
-    if ON_WINDOWS:
-        if (options):
-            return ["node", libPath, options]
-        else:
-            return ["node", libPath]
+    if (options):
+        return ["node", libPath, options]
     else:
-        if (options):
-            return "{0} '{1}' '{2}'".format("/usr/local/bin/node", libPath, options)
-        else:
-            return "{0} '{1}'".format("/usr/local/bin/node", libPath)
+        return ["node", libPath]
 
 class NodeCheck:
     '''This class check whether node.js is installed and available in the path.

--- a/lib/command_line.js
+++ b/lib/command_line.js
@@ -1,3 +1,4 @@
+;(function () {
 var buf = '';
 var esformatter = require('formatter');
 var options = JSON.parse(process.argv[2] || "{}");
@@ -14,3 +15,4 @@ process.stdin.on('end', function() {
 });
 
 process.stdin.resume();
+})();

--- a/lib/doStuff.js
+++ b/lib/doStuff.js
@@ -5,6 +5,9 @@ var browserify = require("browserify");
 var esformatterDir = "./node_modules/esformatter";
 var cli = fs.readFileSync("./command_line.js", "utf8");
 
+var esversion = require(__dirname + "/node_modules/esformatter/package.json").version;
+esversion = "\n//based on esformatter " + esversion;
+
 var b = browserify({
 	basedir: esformatterDir
 });
@@ -12,7 +15,7 @@ b.require("./lib/esformatter.js", {
 	expose: "formatter"
 });
 b.bundle(function (err, src) {
-	fs.writeFileSync("esformatter.js", "#!/usr/bin/env node\n" + src + cli);
+	fs.writeFileSync("esformatter.js", "#!/usr/bin/env node\n" + src + cli + esversion);
 });
 
 var settings = fs.readFileSync("./sublime.settings", "utf8");

--- a/lib/esformatter.js
+++ b/lib/esformatter.js
@@ -6647,7 +6647,8 @@ var esprima = require('esprima');
 
 // ---
 
-var BYPASS_RECURSION = {
+// we expose the flags so other tools can tweak the values (#8)
+exports.BYPASS_RECURSION = {
     root : true,
     comments : true,
     tokens : true,
@@ -6679,6 +6680,7 @@ var _addLocInfo;
 // parse string and return an augmented AST
 exports.parse = function parse(source, opts){
     _addLocInfo = opts && opts.loc;
+    source = source.toString();
 
     var ast = esprima.parse(source, {
         loc : _addLocInfo,
@@ -6687,7 +6689,13 @@ exports.parse = function parse(source, opts){
         comment : true
     });
 
-    // ast.source = source;
+    // we augment just root node since program is "empty"
+    // can't check `ast.body.length` because it might contain just comments
+    if (!ast.tokens.length && !ast.comments.length) {
+        ast.depth = 0;
+        ast.startToken = ast.endToken = null;
+        return ast;
+    }
 
     instrumentTokens(ast, source);
 
@@ -6990,7 +6998,7 @@ function recursiveWalk(node, fn, parent, prev, next){
 
         // only need to recurse real nodes and arrays
         // ps: typeof null == 'object'
-        if (!child || typeof child !== 'object' || BYPASS_RECURSION[key]) {
+        if (!child || typeof child !== 'object' || exports.BYPASS_RECURSION[key]) {
             continue;
         }
 
@@ -7040,7 +7048,8 @@ exports.moonwalk = function moonwalk(ast, fn){
 
 
 },{"esprima":56}]},{},[])
-;var buf = '';
+;;(function () {
+var buf = '';
 var esformatter = require('formatter');
 var options = JSON.parse(process.argv[2] || "{}");
 
@@ -7056,3 +7065,5 @@ process.stdin.on('end', function() {
 });
 
 process.stdin.resume();
+})();
+//based on esformatter 0.0.15


### PR DESCRIPTION
- On start it checks that node is installed and executable. If not gives a meaningful error.
- When formatting multiple lines try first to format the whole line and in case of error, only the selection
