### PR TITLE
Path: extend path for Node installed on /usr/local/bin

### DIFF
--- a/EsFormatter.py
+++ b/EsFormatter.py
@@ -4,6 +4,9 @@ ON_WINDOWS = platform.system() is 'Windows'
 ST2 = sys.version_info < (3, 0)
 NODE = None
 
+# Extend Path to catch Node installed via HomeBrew
+os.environ['PATH'] += ':/usr/local/bin'
+
 class EsformatterCommand(sublime_plugin.TextCommand):
     def run(self, edit):
         if (NODE.mightWork() == False):


### PR DESCRIPTION
Fixes #17

Blame on me, I got this from [StackOverflow](http://stackoverflow.com/questions/8574919/sublime-text-2-custom-path-and-pythonpath). I'm really not experienced with Python and I can't say this is ok or shit.

Also, calling a friend for a third part opinion: @henriquebastos (sorry, I don't know anyone else better to help me here).
