### PR TITLE
Extend NODE_PATH with NPMs global module root

### DIFF
--- a/EsFormatter.py
+++ b/EsFormatter.py
@@ -12,6 +12,22 @@ if not ON_WINDOWS:
     # Extend Path to catch Node installed via HomeBrew
     os.environ['PATH'] += ':/usr/local/bin'
 
+def getNpmGlobalRoot():
+    # determine NPM global root
+    try:
+        return subprocess.check_output(["npm", "root", "-g"]).rstrip().decode('utf-8')
+    except:
+        # NPM not installed or not accessible
+        return None
+
+# Extend NODE_PATH to make globally installed esformatter requirable
+npmRoot = getNpmGlobalRoot()
+if npmRoot:
+    if hasattr(os.environ, 'NODE_PATH'):
+        os.environ['NODE_PATH'] += os.pathsep + npmRoot
+    else:
+        os.environ['NODE_PATH'] = npmRoot
+
 class EsformatterCommand(sublime_plugin.TextCommand):
     def run(self, edit, save=False, ignoreSelection=False):
         # Settings for formatting


### PR DESCRIPTION
Usage of a provided `esformatter` module instead of the bundled one is already prepared in `command_line.js` but this does only work if `esformatter` is installed in the local `node_modules` directory but not for global installs.

This changeset extends `NODE_PATH` with NPMs global module root in order to support loading of a globally installed `esformatter`. In addition to that, this fixes https://github.com/piuccio/sublime-esformatter/issues/40 as when using the globally installed `esformatter`, modules also globally installed alongside work as expected.

**Note:** The global module folder of NPM is not added to `NODE_PATH` automatically, so `require('esformatter')` will not work in this case out-of-the-box. See the docs https://nodejs.org/api/modules.html#modules_loading_from_the_global_folders for a list of paths that are added automatically.
