### PR TITLE
Platform independent file paths for esformatter finder code

### DIFF
--- a/EsFormatter.py
+++ b/EsFormatter.py
@@ -39,7 +39,7 @@ class NodeCheck:
             self.works = False
 
 def findExecutablePath(folder):
-    target = os.path.join(folder, 'node_modules\\esformatter\\bin\\esformatter')
+    target = os.path.join(folder, 'node_modules', 'esformatter', 'bin', 'esformatter')
     if (os.path.isfile(target)):
         return target
     else:


### PR DESCRIPTION
Concatenating folder var and the string returns a path with mixed \ and // in a linux environment.
This change will let python concatenate the path with the right separator for the current os.