### PR TITLE
Obey EndOfFile esformatter rule

### DIFF
--- a/EsFormatter.py
+++ b/EsFormatter.py
@@ -1,4 +1,4 @@
-import sublime, sublime_plugin, subprocess, threading, json, platform, sys, os
+import sublime, sublime_plugin, subprocess, threading, json, re, platform, sys, os
 
 ON_WINDOWS = platform.system() is 'Windows'
 ST2 = sys.version_info < (3, 0)

--- a/EsFormatter.py
+++ b/EsFormatter.py
@@ -206,6 +206,12 @@ class NodeCall(threading.Thread):
         self.result = None
         threading.Thread.__init__(self)
 
+    def readResult(self, stdout):
+        if ST2:
+            return stdout.decode('utf-8')
+        else:
+            return str(stdout, encoding='utf-8')
+
     def run(self):
         try:
             sublime.status_message("Formatting file...")
@@ -228,19 +234,16 @@ class NodeCall(threading.Thread):
                 stderr=subprocess.PIPE,
                 startupinfo=getStartupInfo())
 
-            if ST2:
-                stdout, stderr = process.communicate(self.code)
-                self.result = stdout.decode('utf-8')
-            else:
-                stdout, stderr = process.communicate(self.code)
-                self.result = str(stdout, encoding='utf-8')
+            stdout, stderr = process.communicate(self.code)
 
             if stderr:
                 self.result = False
-                if ST2:
-                    self.error = str(stderr.decode('utf-8'))
-                else:
-                    self.error = str(stderr, encoding='utf-8')
+                self.error = self.readResult(stderr)
+            else:
+                self.result = self.readResult(stdout)
+
+                if self.region:
+                    self.result = re.sub(r'(\r|\r\n|\n)\Z', '', self.result)
 
         except Exception as e:
             self.result = False

--- a/EsFormatter.py
+++ b/EsFormatter.py
@@ -1,4 +1,4 @@
-import sublime, sublime_plugin, subprocess, threading, json, re, platform, sys, os
+import sublime, sublime_plugin, subprocess, threading, json, platform, sys, os
 
 ON_WINDOWS = platform.system() is 'Windows'
 ST2 = sys.version_info < (3, 0)
@@ -230,10 +230,10 @@ class NodeCall(threading.Thread):
 
             if ST2:
                 stdout, stderr = process.communicate(self.code)
-                self.result = re.sub(r'(\r|\r\n|\n)\Z', '', stdout).decode('utf-8')
+                self.result = stdout.decode('utf-8')
             else:
                 stdout, stderr = process.communicate(self.code)
-                self.result = re.sub(r'(\r|\r\n|\n)\Z', '', str(stdout, encoding='utf-8'))
+                self.result = str(stdout, encoding='utf-8')
 
             if stderr:
                 self.result = False


### PR DESCRIPTION
I noticed sublime esformatter was removing the trailing newline at the end files, in spite of the fact that I have `before.EndOfFile` set to 1 in my `.esformatter`.

I found the culprit in this plugin. The offending line of code predates the `EndOfFile` option which was introduced here: https://github.com/millermedeiros/esformatter/issues/111 so it seems the regex replacement may no longer be necessary.

With this change sublime-esformatter will obey esformatter's decision on EOF newlines.

But if there was another good reason for removing trailing newlines, feel free to close this PR :)